### PR TITLE
Kargo: Enable gzip compression

### DIFF
--- a/src/main/resources/bidder-config/kargo.yaml
+++ b/src/main/resources/bidder-config/kargo.yaml
@@ -1,6 +1,7 @@
 adapters:
   kargo:
     endpoint: https://krk.kargo.com/api/v1/openrtb
+    endpoint-compression: gzip
     modifyingVastXmlAllowed: true
     meta-info:
       maintainer-email: kraken@kargo.com


### PR DESCRIPTION
[KRAK-3880](https://kargo1.atlassian.net/browse/KRAK-3880): Enables gzip compression for incoming Prebid s2s requests